### PR TITLE
Fix safeGet default return handling

### DIFF
--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -31,7 +31,13 @@ const getAllContentBeaches = (): ContentBeach[] => {
 // Transform content beach to UI beach format
 const transformBeachForUI = (contentBeach: ContentBeach): Beach => {
   const safeGet = (obj: any, path: string, defaultValue: any) => {
-    return path.split('.').reduce((acc, key) => acc && acc[key] !== 'undefined' ? acc[key] : defaultValue, obj);
+    const result = path.split('.').reduce((acc: any, key: string) => {
+      if (typeof acc === 'undefined' || typeof acc[key] === 'undefined') {
+        return undefined;
+      }
+      return acc[key];
+    }, obj);
+    return typeof result === 'undefined' ? defaultValue : result;
   };
 
   return {


### PR DESCRIPTION
## Summary
- use `typeof` checks inside `safeGet`
- preserve `defaultValue` when a path is missing

## Testing
- `npm run lint` *(fails: eslint errors)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6863733aeae8832fa905eda690929a25