### PR TITLE
Fix homepage state counts

### DIFF
--- a/src/components/Homepage.tsx
+++ b/src/components/Homepage.tsx
@@ -229,7 +229,7 @@ const Homepage: React.FC<HomepageProps> = ({ onSearch, onBeachSelect }) => {
           <div className="relative">
             <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-6">
               {states.map((state, index) => {
-                const stateBeaches = featuredBeaches.filter(beach => beach.state === state);
+                const stateBeaches = allBeaches.filter(beach => beach.state === state);
                 return (
                   <button
                     key={index}


### PR DESCRIPTION
## Summary
- fix state beach counts by pulling from all beaches

## Testing
- `npm run lint` *(fails: Unexpected any, unused vars)*

------
https://chatgpt.com/codex/tasks/task_e_686390537c2c832f97a0e6ec1c2bb906