### PR TITLE
Preserve image captions in beach data

### DIFF
--- a/src/components/BeachProfile.tsx
+++ b/src/components/BeachProfile.tsx
@@ -33,8 +33,8 @@ const BeachProfile: React.FC<BeachProfileProps> = ({ beach, onWriteReview }) => 
         {/* Hero Gallery */}
         <div className="relative h-96 md:h-[500px] rounded-3xl overflow-hidden shadow-2xl mb-8">
           <img
-            src={beach.images[currentImageIndex]}
-            alt={beach.name}
+            src={beach.images[currentImageIndex].url}
+            alt={beach.images[currentImageIndex].caption || beach.name}
             className="w-full h-full object-cover"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-dark-slate/60 via-transparent to-transparent"></div>
@@ -257,8 +257,8 @@ const BeachProfile: React.FC<BeachProfileProps> = ({ beach, onWriteReview }) => 
                         onClick={() => setCurrentImageIndex(index)}
                       >
                         <img
-                          src={image}
-                          alt={`${beach.name} ${index + 1}`}
+                          src={image.url}
+                          alt={image.caption || `${beach.name} ${index + 1}`}
                           className="w-full h-full object-cover"
                         />
                       </div>

--- a/src/components/Homepage.tsx
+++ b/src/components/Homepage.tsx
@@ -65,9 +65,9 @@ const Homepage: React.FC<HomepageProps> = ({ onSearch, onBeachSelect }) => {
                 index === currentHeroIndex ? 'opacity-100' : 'opacity-0'
               }`}
             >
-              <div 
+              <div
                 className="w-full h-full bg-cover bg-center bg-no-repeat transform scale-105"
-                style={{ backgroundImage: `url(${image})` }}
+                style={{ backgroundImage: `url(${image.url})` }}
               />
             </div>
           ))}

--- a/src/components/InteractiveMap.tsx
+++ b/src/components/InteractiveMap.tsx
@@ -139,8 +139,8 @@ const MapController: React.FC<{
               <div className="relative mb-3">
                 {beach.images && beach.images.length > 0 ? (
                   <img
-                    src={beach.images[0]}
-                    alt={beach.name}
+                    src={beach.images[0].url}
+                    alt={beach.images[0].caption || beach.name}
                     className="w-full h-32 object-cover rounded-lg"
                   />
                 ) : (

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -311,8 +311,8 @@ const SearchResults: React.FC<SearchResultsProps> = ({ searchQuery, onBeachSelec
                     <div className="md:flex">
                       <div className="md:w-96 h-80 md:h-auto relative overflow-hidden">
                         <img
-                          src={beach.images[0]}
-                          alt={beach.name}
+                          src={beach.images[0].url}
+                          alt={beach.images[0].caption || beach.name}
                           className="w-full h-full object-cover group-hover:scale-110 transition-transform duration-700"
                         />
                         <div className="absolute inset-0 bg-gradient-to-t from-dark-slate/60 via-transparent to-transparent"></div>

--- a/src/types/Content.ts
+++ b/src/types/Content.ts
@@ -127,7 +127,10 @@ export interface Beach {
   description: string;
   rating: number;
   reviewCount: number;
-  images: string[];
+  images: Array<{
+    url: string;
+    caption: string;
+  }>;
   amenities: string[];
   activities: string[];
   vibe: string[];

--- a/src/utils/contentLoader.ts
+++ b/src/utils/contentLoader.ts
@@ -48,7 +48,10 @@ const transformBeachForUI = (contentBeach: ContentBeach): Beach => {
     description: contentBeach.detailed_description,
     rating: safeGet(contentBeach, 'user_content.ratings.average', 0),
     reviewCount: safeGet(contentBeach, 'user_content.ratings.count', 0),
-    images: (contentBeach.images || []).map(img => img.url),
+    images: (contentBeach.images || []).map(img => ({
+      url: img.url,
+      caption: img.caption
+    })),
     amenities: safeGet(contentBeach, 'attributes.amenities', []),
     activities: safeGet(contentBeach, 'attributes.activities', []),
     vibe: safeGet(contentBeach, 'attributes.best_for', []),


### PR DESCRIPTION
## Summary
- keep image captions when loading content
- expose captions via Beach type
- render captions as `alt` text in map popups, profiles, and search results
- show hero carousel backgrounds from new image objects

## Testing
- `npm install`
- `npm run lint` *(fails: no-unused-vars etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6863980d9518832fbb94878ef4ff9386