### PR TITLE
Add SEO Helmet integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "lucide-react": "^0.344.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
+        "react-helmet-async": "^2.0.5",
         "react-leaflet": "^4.2.1"
       },
       "devDependencies": {
@@ -2600,6 +2601,15 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
+      }
+    },
     "node_modules/is-binary-path": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
@@ -3327,6 +3337,26 @@
         "react": "^18.3.1"
       }
     },
+    "node_modules/react-fast-compare": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/react-fast-compare/-/react-fast-compare-3.2.2.tgz",
+      "integrity": "sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==",
+      "license": "MIT"
+    },
+    "node_modules/react-helmet-async": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/react-helmet-async/-/react-helmet-async-2.0.5.tgz",
+      "integrity": "sha512-rYUYHeus+i27MvFE+Jaa4WsyBKGkL6qVgbJvSBoX8mbsWoABJXdEO0bZyi0F6i+4f0NuIb8AvqPMj3iXFHkMwg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "react-fast-compare": "^3.2.2",
+        "shallowequal": "^1.1.0"
+      },
+      "peerDependencies": {
+        "react": "^16.6.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/react-leaflet": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-4.2.1.tgz",
@@ -3485,6 +3515,12 @@
       "bin": {
         "semver": "bin/semver.js"
       }
+    },
+    "node_modules/shallowequal": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/shallowequal/-/shallowequal-1.1.0.tgz",
+      "integrity": "sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==",
+      "license": "MIT"
     },
     "node_modules/shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lucide-react": "^0.344.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
+    "react-helmet-async": "^2.0.5",
     "react-leaflet": "^4.2.1"
   },
   "devDependencies": {

--- a/src/components/BeachProfile.tsx
+++ b/src/components/BeachProfile.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from 'react';
+import { Helmet } from 'react-helmet-async';
 import { Star, MapPin, Thermometer, Calendar, Shield, Users, Waves, Car, Navigation, Camera, ChevronLeft, ChevronRight, ExternalLink } from 'lucide-react';
 import { Beach, ContentBeach } from '../types/Content';
 
@@ -29,6 +30,30 @@ const BeachProfile: React.FC<BeachProfileProps> = ({ beach, onWriteReview }) => 
 
   return (
     <div className="min-h-screen pt-8">
+      <Helmet>
+        <title>{beach.name} - Pantai.my</title>
+        <meta name="description" content={beach.description} />
+        <script type="application/ld+json">
+          {JSON.stringify({
+            '@context': 'https://schema.org',
+            '@type': 'Beach',
+            name: beach.name,
+            description: beach.description,
+            image: beach.images[0],
+            aggregateRating: {
+              '@type': 'AggregateRating',
+              ratingValue: beach.rating,
+              reviewCount: beach.reviewCount,
+            },
+            address: {
+              '@type': 'PostalAddress',
+              addressLocality: beach.location,
+              addressRegion: beach.state,
+              addressCountry: 'Malaysia',
+            },
+          })}
+        </script>
+      </Helmet>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Hero Gallery */}
         <div className="relative h-96 md:h-[500px] rounded-3xl overflow-hidden shadow-2xl mb-8">

--- a/src/components/Homepage.tsx
+++ b/src/components/Homepage.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Helmet } from 'react-helmet-async';
 import { Search, MapPin, Star, Users, Waves, Camera, ArrowRight, Play, ChevronDown, Map } from 'lucide-react';
 import { getAllStates, getFeaturedBeaches, getAllBeaches } from '../utils/contentLoader';
 import { Beach } from '../types/Content';
@@ -54,6 +55,13 @@ const Homepage: React.FC<HomepageProps> = ({ onSearch, onBeachSelect }) => {
 
   return (
     <div className="min-h-screen">
+      <Helmet>
+        <title>Pantai.my - Discover Malaysia's Beaches</title>
+        <meta
+          name="description"
+          content="Explore Malaysia's most beautiful beaches and plan your next getaway with Pantai.my."
+        />
+      </Helmet>
       {/* Immersive Hero Section */}
       <section className="relative h-screen overflow-hidden">
         {/* Background Image Carousel */}

--- a/src/components/SearchResults.tsx
+++ b/src/components/SearchResults.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Helmet } from 'react-helmet-async';
 import { List, Map, Filter, Star, MapPin, Waves, Users, Car, Wifi, ArrowRight, Eye, Heart } from 'lucide-react';
 import { Beach, FilterOptions } from '../types/Content';
 import { searchBeaches, getAllActivities, getAllAmenities, getAllStates, getAllVibes } from '../utils/contentLoader';
@@ -105,6 +106,13 @@ const SearchResults: React.FC<SearchResultsProps> = ({ searchQuery, onBeachSelec
 
   return (
     <div className="min-h-screen pt-8 bg-gradient-to-b from-sandy-beige to-white">
+      <Helmet>
+        <title>Search results for {searchQuery} - Pantai.my</title>
+        <meta
+          name="description"
+          content={`Discover beaches matching "${searchQuery}" on Pantai.my.`}
+        />
+      </Helmet>
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         {/* Cinematic Search Header */}
         <div className="mb-12 text-center">

--- a/src/components/VisitMalaysia2026.tsx
+++ b/src/components/VisitMalaysia2026.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { Helmet } from 'react-helmet-async';
 import { 
   Calendar, 
   MapPin, 
@@ -90,6 +91,13 @@ const VisitMalaysia2026: React.FC<VisitMalaysia2026Props> = ({ onBeachSelect }) 
 
   return (
     <div className="min-h-screen bg-gradient-to-b from-white to-sandy-beige">
+      <Helmet>
+        <title>Visit Malaysia 2026 - Pantai.my</title>
+        <meta
+          name="description"
+          content="Discover Visit Malaysia 2026 destinations and plan your beach adventures with Pantai.my."
+        />
+      </Helmet>
       {/* Hero Section with VM2026 Branding */}
       <section className="relative py-32 px-4 overflow-hidden">
         <div className="absolute inset-0 bg-gradient-to-br from-blue-50 via-white to-red-50"></div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { HelmetProvider } from 'react-helmet-async';
 import App from './App.tsx';
 import './index.css';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <HelmetProvider>
+      <App />
+    </HelmetProvider>
   </StrictMode>
 );


### PR DESCRIPTION
## Summary
- add `react-helmet-async`
- wrap the app with `<HelmetProvider>`
- set page titles and descriptions with Helmet
- create dynamic JSON‑LD metadata on the beach profile

## Testing
- `npm run lint` *(fails: no-unused-vars and no-explicit-any errors)*

------
https://chatgpt.com/codex/tasks/task_e_6863980d1fa8832f887141c59561b380